### PR TITLE
Add terminput

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [coolor](https://github.com/Canop/coolor) - Tiny color conversion library for TUI application builders.
 - [ratatui-macros](https://github.com/kdheepak/ratatui-macros) - Macros for simplifying boilerplate for creating UI using Ratatui.
 - [tachyonfx](https://github.com/junkdog/tachyonfx) - A shader-like effects library for ratatui.
+- [terminput](https://crates.io/crates/terminput) - An abstraction over various backends that provide input events.
 - [tui-input](https://crates.io/crates/tui-input) - A headless input library for TUI apps.
 
 ## 💻 Apps


### PR DESCRIPTION
* **Link to your project (GitHub/crates.io):**
  * https://github.com/aschey/terminput
  * https://crates.io/crates/terminput 

* **Description (optional):** This doesn't have a direct dependency on Ratatui, but it was mostly created out of a need to have a common interface for multiple Ratatui backends. Some third-party Ratatui libraries currently have a hard dependency on `crossterm` (or one of either `crossterm`, `termwiz`, or `termion`, at best) solely for their input types. `terminput` is an attempt to provide that abstraction for a greater variety of backends.

<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->