### PR TITLE
Add envx to the list of TUI applications in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [csvlens](https://github.com/YS-L/csvlens) - Command line csv viewer.
 - [dead-ringer](https://github.com/ztroop/dead-ringer) - Binary diff tool for Hex/ASCII analysis.
 - [diskonaut](https://github.com/imsnif/diskonaut) - Terminal-based disk space navigator.
+- [envx](https://github.com/mikeleppane/envx) - Environment variable manager for developers, featuring an intuitive TUI.
 - [exabind](https://github.com/junkdog/exabind) - An animated TUI for viewing KDE shortcuts.
 - [exhaust](https://github.com/heyrict/exhaust) - Exhaust all your possibilities for the next coming exam.
 - [flawz](https://github.com/orhun/flawz) - A TUI for browsing security vulnerabilities (CVEs).


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): <!-- paste here -->
https://github.com/mikeleppane/envx


* Description (optional):  <!-- short summary -->
A powerful and secure environment variable manager for developers, featuring an intuitive Terminal User Interface (TUI) and comprehensive command-line interface.

* Screenshot or gif (strongly recommended): <!-- drag & drop or link -->

<img width="800" height="600" alt="main" src="https://github.com/user-attachments/assets/4261e557-ba63-4cb6-8f4b-4aa6ac7d1628" />

<img width="800" height="600" alt="query" src="https://github.com/user-attachments/assets/c2ab48e4-9418-4047-869b-180c8ce0689d" />



<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->