### PR TITLE
Propose file change:  add SC-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [rucola](https://github.com/Linus-Mussmaecher/rucola) - Terminal-based markdown note manager.
 - [Rust-Kanban](https://github.com/yashs662/rust_kanban) - A kanban board for the terminal.
 - [rusty-krab-manager](https://github.com/aryakaul/rusty-krab-manager) - Rime management TUI in Rust.
-- [sc-cli](https://github.com/lnds/sc-cli) - SC-CLI a TUI for Shorcut (formerly clubhouse) project management tool.
+- [sc-cli](https://github.com/lnds/sc-cli) - A TUI for Shortcut (formerly know as Clubhouse) a project management tool for teams.
 - [stu](https://github.com/lusingander/stu) - A TUI for AWS S3.
 - [synd](https://github.com/ymgyt/syndicationd) - A TUI feed viewer.
 - [sheetsui](https://github.com/zaphar/sheetsui) - A terminal based spreadsheet application.


### PR DESCRIPTION
Add SC-CLI to the awesome-ratatui list.


<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): https://github.com/lnds/sc-cli

* Description (optional): 

SC-CLI is a TUI for Shortcut (formerly known as clubhouse).
Shortcut is a project management tool for teams.
This in an unofficial tool that interact with the API provided by Shortcut.

* Screenshot or gif (strongly recommended): 

<img width="1453" height="856" alt="image" src="https://github.com/user-attachments/assets/ffed7b40-a633-4961-a60d-9fce072a39e4" />

