### PR TITLE
Add framework-tool-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [dua-cli](https://github.com/Byron/dua-cli) - View disk space usage and delete unwanted data, fast.
 - [ducker](https://github.com/robertpsoane/ducker) - A terminal app for managing Docker containers, inspired by K9s.
 - [erldash](https://github.com/sile/erldash) - A simple, terminal-based Erlang dashboard.
-- [framework-tool-tui](https://github.com/grouzen/framework-tool-tui) - TUI for controlling and monitoring Framework Computers hardware built in Rust.
+- [framework-tool-tui](https://github.com/grouzen/framework-tool-tui) - A TUI for controlling and monitoring Framework Computers hardware.
 - [kdash](https://github.com/kdash-rs/kdash) - A simple and fast dashboard for Kubernetes.
 - [kftui](https://github.com/hcavarsan/kftray/blob/main/README.md#kftui) - A TUI to manage multiple kubectl port-forward commands, with support for UDP and Kubernetes proxy.
 - [kmon](https://github.com/orhun/kmon) - Linux Kernel Manager and Activity Monitor.


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): https://github.com/grouzen/framework-tool-tui

* Description (optional): A snappy TUI dashboard for controlling and monitoring your Framework Laptop hardware — charging, privacy, lighting, USB PD ports, and more.

* Screenshot or gif (strongly recommended): 

![demo](https://github.com/user-attachments/assets/762ef092-aef4-4609-bcd6-abc61b2c4c8d)

