### PR TITLE
Add tui-piechart to list of ratatui widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [tui-tree-widget](https://crates.io/crates/tui-tree-widget) - Tree widget for ratatui.
 - [tui-widget-list](https://crates.io/crates/tui-widget-list) - A versatile list implementation for ratatui.
 - [tui-checkbox](https://crates.io/crates/tui-checkbox) - A customizable checkbox widget for ratatui.
-- [tui-piechart](https://crates.io/crates/tui-piechart) - An ergonomic piechart that comes in Standard and Braille (8x sharper) resolution.
+- [tui-piechart](https://crates.io/crates/tui-piechart) - A configurable, colorful piechart widget that comes in standard and high resolution.
 
 ### 🔧 Utilities
 


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

Introducing the [tui-piechart](https://github.com/sorinirimies/tui-piechart)

A customisable [tui-piechart](https://github.com/sorinirimies/tui-piechart) widget that comes in normal and high resolution designed for [ratatui](https://github.com/ratatui/ratatui) 
![high_resolution](https://github.com/user-attachments/assets/5a3d39a8-96e2-469d-bc6e-fa85d2dc5f66)

<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->