### PR TITLE
Add oeis-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [maccel](https://github.com/Gnarus-G/maccel) - A mouse acceleration driver for Linux, and a TUI to control some parameters.
 - [mlbt](https://github.com/mlb-rs/mlbt) - A tui for the MLB Statcast API. Watch a live game using Gameday, or check scores, standings, and stats.
 - [nyaa](https://github.com/Beastwick18/nyaa) - A nyaa.si tui tool for browsing and downloading torrents.
+- [oeis-tui](https://github.com/hako/oeis-tui) - A TUI and CLI for browsing the On-Line Encyclopedia of Integer Sequences (OEIS) in the terminal.
 - [poketex](https://github.com/ckaznable/poketex) - Simple Pokedex based on TUI.
 - [Raijin](https://github.com/MasonStooksbury/Raijin) - A free, simple weather TUI that pulls data without the need for an API key, account, or subscription.
 - [rsfrac](https://github.com/SkwalExe/rsfrac) - Terminal based fractal explorer, including Mandelbrot, Burning Ship, and Julia.


### PR DESCRIPTION
https://github.com/hako/oeis-tui

oeis-tui is a TUI and CLI for browsing the On-Line Encyclopedia of Integer Sequences (OEIS) in the terminal.

<img width="3360" height="1766" alt="oeis-tui" src="https://github.com/user-attachments/assets/0c863f6f-332c-4a92-9f62-2cdb22231dbb" />

https://github.com/user-attachments/assets/ce63baf7-1bfc-4ae7-8c27-5b33b5ee2bf5