### PR TITLE
Add git-time-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [giff](https://github.com/bahdotsh/giff) - A TUI for Git diffs with interactive rebase support.
 - [gimoji](https://github.com/zeenix/gimoji) - Makes it easy to add emojis to your Git commit messages.
 - [gitu](https://github.com/altsem/gitu) - A TUI Git client inspired by Magit.
+- [git-time-machine](https://github.com/dinakars777/git-time-machine) - Visual git reflog TUI for undoing git mistakes.
 - [gitui](https://github.com/extrawurst/gitui) - Terminal UI for Git.
 - [glim](https://github.com/junkdog/glim) - Monitor GitLab CI/CD pipelines and projects with style.
 - [gobang](https://github.com/TaKO8Ki/gobang) - Cross-platform TUI database management tool.


### PR DESCRIPTION
Add git-time-machine to the Development Tools section.

git-time-machine is a visual git reflog TUI built with Ratatui that makes recovering from git mistakes easy and interactive.

**Features:**
- Visual timeline of git history with relative timestamps
- One-key restore to any previous state
- Scrollable diff preview
- Vim-style keybindings
- Built with Rust and Ratatui

**Links:**
- GitHub: https://github.com/dinakars777/git-time-machine
- Crates.io: https://crates.io/crates/git-time-machine

Available via: `cargo install git-time-machine`