### PR TITLE
Add opaline

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [bevy_ratatui](https://github.com/joshka/bevy_ratatui) - A Rust crate to use Ratatui in a Bevy App.
 - [color-to-tui](https://crates.io/crates/color-to-tui) - Parse colors and convert them to `ratatui::style::Colors`.
 - [coolor](https://github.com/Canop/coolor) - Tiny color conversion library for TUI application builders.
+- [opaline](https://crates.io/crates/opaline) - Token-based theme engine for Ratatui with gradients, 20 builtin themes, user theme discovery, and a reusable theme selector widget.
 - [ratatui-garnish](https://github.com/franklaranja/ratatui-garnish) - A powerful composition system for Ratatui widgets.
 - [ratatui-macros](https://github.com/kdheepak/ratatui-macros) - Macros for simplifying boilerplate for creating UI using Ratatui.
 - [ratatui-input-manager](https://crates.io/ratatui-input-manager) - A macro for creating declarative update handlers in Elm style apps, supporting crossterm, termion and termwiz.


### PR DESCRIPTION
[opaline](https://crates.io/crates/opaline) is a token-based theme engine built specifically for Ratatui applications.

It ships 20 builtin themes (SilkCircuit variants, Nord, Dracula, Tokyo Night, and more), supports TOML-based user themes auto-discovered from XDG config directories, and includes gradient support and a reusable ThemeSelector StatefulWidget with live preview and exact-snapshot rollback.

There is no existing dedicated theme engine in the Utilities section, so this fills a gap for Ratatui app authors who want consistent, pluggable theming.

- Repo: https://github.com/hyperb1iss/opaline
- Crate: https://crates.io/crates/opaline
- License: MIT

Entry added alphabetically to the Libraries > Utilities section.