### PR TITLE
Add tui-overlay widget to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [tui-logger](https://crates.io/crates/tui-logger) - Logger with smart widget for ratatui.
 - [tui-menu](https://github.com/shuoli84/tui-menu) - A menu widget for ratatui ecosystem.
 - [tui-nodes](https://crates.io/crates/tui-nodes) - Node graph visualization.
+- [tui-overlay](https://crates.io/crates/tui-overlay) - A composable overlay widget with drawers, modals, popovers, and toasts from a single configurable primitive.
 - [tui-popup](https://github.com/joshka/tui-popup) - A Popup widget for Ratatui.
 - [tui-prompts](https://crates.io/crates/tui-prompts) - A library for building interactive prompts for ratatui.
 - [tui-rain](https://github.com/levilutz/tui-rain) - A widget to generate various rain effects.


### PR DESCRIPTION
Added tui-overlay widget to the list of ratatui ecosystem components.

<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): 
https://crates.io/crates/tui-overlay
https://github.com/jharsono/tui-overlay

* Description (optional):  <!-- short summary -->
A composable overlay widget with drawers, modals, popovers, and toasts from a single configurable primitive.

* Screenshot or gif (strongly recommended): <!-- drag & drop or link -->
<img width="1280" height="532" alt="image" src="https://raw.githubusercontent.com/jharsono/tui-overlay/main/screenshots/demo.gif" />
<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->