### PR TITLE
Add ratatui-stacked-bar widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [ratatui-image](https://crates.io/crates/ratatui-image) - An image widget for ratatui, supporting sixels and unicode-halfblocks.
 - [ratatui-fretboard](https://crates.io/crates/ratatui-fretboard) - A widget for displaying musical note positions on a fretboard.
 - [ratatui-splash-screen](https://github.com/orhun/ratatui-splash-screen) - A widget to turn any image to a splash screen.
+- [ratatui-stacked-bar](https://github.com/zeqianli/ratatui-stacked-bar) - A stacked area chart widget for ratatui.
 - [ratatui-textarea](https://crates.io/crates/ratatui-textarea) - A simple yet powerful editor widget for ratatui. Fork of `tui-textarea`.
 - [ratatui-toaster](https://crates.io/crates/ratatui-toaster) - An extremely lightweight toast engine for ratatui.
 - [ratatui-cheese](https://crates.io/crates/ratatui-cheese) - Bubbletea-inspired widgets for ratatui, including spinner, help, tree, paginator and list.


### PR DESCRIPTION
Adds [ratatui-stacked-bar](https://github.com/zeqianli/ratatui-stacked-bar) to the Widgets section.

Posted this before on [Ratatui discussion](https://github.com/ratatui/ratatui/discussions/2056)

AI disclosure: Code logic has no AI code. Claude helped with documentation and chore.