### PR TITLE
Add classfi

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [bookokrat](https://github.com/bugzmanov/bookokrat) - A full-featured EPUB / PDF e-book reader with Vim keybindings.
 - [bytebeat-rs](https://github.com/chaosprint/bytebeat-rs) - A TUI for bytebeat.
 - [chordflow](https://github.com/timvancann/chordflow) - A tool for practicing improvisation and mastering the guitar neck.
+- [classfi](https://github.com/carmiac/classfi) - A focused streaming music player for classical music.
 - [deezer-tui](https://github.com/Tatayoyoh/deezer-tui) - Deezer music TUI with included background player.
 - [fum](https://github.com/qxb3/fum) - A fully ricable tui-based music client.
 - [glicol-cli](https://github.com/glicol/glicol-cli) - Cross-platform music live coding in terminal.


### PR DESCRIPTION
Adds a link to the classfi music player.

<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): <!-- paste here -->
https://github.com/carmiac/classfi
https://crates.io/crates/classfi

* Description (optional):  <!-- short summary -->
classfi is a focused music player for classical music, inspired by [lowfi](https://github.com/talwat/lowfi)
 
* Screenshot or gif (strongly recommended): <!-- drag & drop or link -->
<img width="1556" height="851" alt="station_select" src="https://github.com/user-attachments/assets/f6b605ea-f334-4240-b51e-8fbcb73e5a98" />

<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->