### PR TITLE
Add ratatui-form library

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [rainfrog](https://github.com/achristmascarl/rainfrog) - A database management TUI for Postgres.
 - [raymon](https://github.com/bnomei/raymon) - Ray logging TUI and MCP Server.
 - [sabiql](https://github.com/riii111/sabiql) - A fast, driver-less TUI for browsing, querying, and editing PostgreSQL databases with vim-like keybindings.
+- [ratatui-form](https://github.com/DavidLiedle/ratatui-form) - A form library for ratatui.
 - [ratifact](https://github.com/adolfousier/ratifact) - Track and manage build artifacts from multiple programming languages.
 - [repgrep](https://github.com/acheronfail/repgrep) - An interactive replacer for ripgrep that makes it easy to find and replace across files on the command line.
 - [scooter](https://github.com/thomasschafer/scooter) - Interactive find and replace in the terminal.


### PR DESCRIPTION
## Summary
- Adds [ratatui-form](https://github.com/DavidLiedle/ratatui-form), a form library for ratatui, to the list of libraries in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)