### PR TITLE
Add claudectl — mission control for Claude Code sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [blippy](https://github.com/AksharP5/blippy) - A keyboard-first TUI for GitHub issues and pull requests.
 - [burn](https://github.com/burn-rs/burn) - Comprehensive Deep Learning framework in Rust.
 - [cargo-selector](https://github.com/lusingander/cargo-selector) - Cargo subcommand to select and execute binary/example targets.
+- [claudectl](https://github.com/mercurialsolo/claudectl) - Mission control for multiple Claude Code sessions with live dashboard, cost tracking, and budget enforcement.
 - [commandOK](https://github.com/64bit/commandOK) - Spotlight-like command generator for your terminal, supports leading LLM providers.
 - [crmux](https://github.com/maedana/crmux) - A TUI viewer for monitoring and managing multiple Claude Code sessions in tmux.
 - [deadbranch](https://github.com/armgabrielyan/deadbranch) - A TUI for cleaning stale Git branches safely.


### PR DESCRIPTION
## What is claudectl?

A TUI dashboard for monitoring and managing multiple Claude Code CLI sessions. Built with ratatui.

**GitHub:** https://github.com/mercurialsolo/claudectl
**Crates.io:** https://crates.io/crates/claudectl

## What it does

- Live dashboard showing status, cost, burn rate, CPU, context window usage, and token counts for all running Claude Code sessions
- Approve permission prompts, kill sessions, and send input without switching terminals
- Per-session budget enforcement with alerts and auto-kill
- Event hooks for automation (Slack alerts, logging, custom scripts)
- Task orchestration with dependency ordering
- Session highlight reel recording
- Supports 7 terminals: Ghostty, Kitty, tmux, WezTerm, Warp, iTerm2, Terminal.app

## Screenshot

[![claudectl demo](https://asciinema.org/a/899569.svg)](https://asciinema.org/a/899569)

## Details

- ~1 MB binary, <50ms startup
- Uses `ratatui = "0.29"`
- MIT licensed
- Published on crates.io: `cargo install claudectl`