### PR TITLE
Add NoctaVox to music-related tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [mal-cli](https://github.com/L4z3x/mal-cli) - A TUI for myanimelist.
 - [managarr](https://github.com/Dark-Alex-17/managarr) - A TUI and CLI for managing all your Servarrs.
 - [manga-tui](https://github.com/josueBarretogit/manga-tui) - Terminal-based manga reader and downloader with image support.
+- [NoctaVox](https://github.com/Jaxx497/noctavox) - A lightweight, customizable TUI music player for local files.
 - [oosc-rs](https://github.com/karasikq/oosc-rs) - An additive wavetable synthesizer for terminal.
 - [roon-tui](https://github.com/TheAppgineer/roon-tui) - Roon Remote for the terminal.
 - [rusty-pipes](https://github.com/dividebysandwich/rusty-pipes) - Sample-based, MIDI-controlled virtual pipe organ instrument.


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

[NoctaVox](https://github.com/Jaxx497/NoctaVox)

Yet another TUI music player- lightweight and customizable, for local files.

<img width="1100" height="725" alt="header" src="https://github.com/user-attachments/assets/b3b91fe3-ba42-4594-a947-814f8af6435d" />

I've finally got around to publishing an actual release and making a crates.io page. I'd love to get this featured on the actual ratatui.rs website if possible. Let me know if there's anything holding the project back from that.