### PR TITLE
Add O₂ project to the README.md list

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [managarr](https://github.com/Dark-Alex-17/managarr) - A TUI and CLI for managing all your Servarrs.
 - [manga-tui](https://github.com/josueBarretogit/manga-tui) - Terminal-based manga reader and downloader with image support.
 - [NoctaVox](https://github.com/Jaxx497/noctavox) - A lightweight, customizable TUI music player for local files.
+- [O₂](https://github.com/coignard/o2) - Rust port of the ORCΛ esoteric programming language and terminal livecoding environment.
 - [oosc-rs](https://github.com/karasikq/oosc-rs) - An additive wavetable synthesizer for terminal.
 - [roon-tui](https://github.com/TheAppgineer/roon-tui) - Roon Remote for the terminal.
 - [rusty-pipes](https://github.com/dividebysandwich/rusty-pipes) - Sample-based, MIDI-controlled virtual pipe organ instrument.


### PR DESCRIPTION
* Link to your project (GitHub/crates.io): https://github.com/coignard/o2
* Description (optional): Rust port of the ORCΛ esoteric programming language and terminal livecoding environment.
* Screenshot or gif (strongly recommended):

![](https://github.com/coignard/o2/blob/main/assets/demo.gif?raw=true)