### PR TITLE
Add AI Image Auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [glim](https://github.com/junkdog/glim) - Monitor GitLab CI/CD pipelines and projects with style.
 - [gobang](https://github.com/TaKO8Ki/gobang) - Cross-platform TUI database management tool.
 - [ilmari](https://github.com/bnomei/ilmari) - Minimal tmux popup radar to track your agents.
+- [image-auditor](https://github.com/0franco/image-auditor) - A Rust TUI that finds & AI-fixes Lighthouse image issues (CLS, lazy loading, WebP, srcset) across your codebase.
 - [joshuto](https://github.com/kamiyaa/joshuto) - Ranger-like terminal file manager written in Rust.
 - [lazyjj](https://github.com/Cretezy/lazyjj) - TUI for the Jujutsu/jj VCS.
 - [lingora-tui](https://github.com/nigeleke/lingora) - Browse, compare and validate Fluent i18n files.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [glim](https://github.com/junkdog/glim) - Monitor GitLab CI/CD pipelines and projects with style.
 - [gobang](https://github.com/TaKO8Ki/gobang) - Cross-platform TUI database management tool.
 - [ilmari](https://github.com/bnomei/ilmari) - Minimal tmux popup radar to track your agents.
-- [image-auditor](https://github.com/0franco/image-auditor) - A Rust TUI that finds & AI-fixes Lighthouse image issues (CLS, lazy loading, WebP, srcset) across your codebase.
+- [image-auditor](https://github.com/0franco/image-auditor) - Find & fix Lighthouse image issues (CLS, lazy loading, WebP, srcset) across your codebase.
 - [joshuto](https://github.com/kamiyaa/joshuto) - Ranger-like terminal file manager written in Rust.
 - [lazyjj](https://github.com/Cretezy/lazyjj) - TUI for the Jujutsu/jj VCS.
 - [lingora-tui](https://github.com/nigeleke/lingora) - Browse, compare and validate Fluent i18n files.


### PR DESCRIPTION
* Project: https://github.com/0franco/image-auditor

* Description: image-auditor is a Rust-powered terminal tool for scanning codebases for image performance issues that can affect Lighthouse scores, Core Web Vitals, SEO, and accessibility. It includes a polished Ratatui-based TUI, fast scanning, JSON export, and optional AI-assisted fixes.

Thank you for maintaining this awesome repository.