### PR TITLE
Add partly-claudy TUI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [mlbt](https://github.com/mlb-rs/mlbt) - A tui for the MLB Statcast API. Watch a live game using Gameday, or check scores, standings, and stats.
 - [nyaa](https://github.com/Beastwick18/nyaa) - A nyaa.si tui tool for browsing and downloading torrents.
 - [oeis-tui](https://github.com/hako/oeis-tui) - A TUI and CLI for browsing the On-Line Encyclopedia of Integer Sequences (OEIS) in the terminal.
+- [partly-claudy](https://github.com/taho-inc/partly-claudy) - Terminal view of Claude status page (status.claude.com).
 - [poketex](https://github.com/ckaznable/poketex) - Simple Pokedex based on TUI.
 - [Raijin](https://github.com/MasonStooksbury/Raijin) - A free, simple weather TUI that pulls data without the need for an API key, account, or subscription.
 - [rsfrac](https://github.com/SkwalExe/rsfrac) - Terminal based fractal explorer, including Mandelbrot, Burning Ship, and Julia.


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): 
[partly-claudy repo](https://github.com/taho-inc/partly-claudy)
[crates.io](https://crates.io/crates/partly-claudy)

* Description (optional): TUI for status.claude.com


* Screenshot or gif (strongly recommended): <!-- drag & drop or link -->
<img width="1152" height="1048" alt="partly-claudy" src="https://github.com/user-attachments/assets/75e489c2-8024-4eff-a618-7ac08969e594" />

<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->