### PR TITLE
Add bosun

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client for your terminal.
 - [BugStalker](https://github.com/godzie44/BugStalker) - Modern rust debugger for Linux x86-64.
 - [blippy](https://github.com/AksharP5/blippy) - A keyboard-first TUI for GitHub issues and pull requests.
+- [bosun](https://github.com/yetidevworks/bosun) - A tmux-native TUI for orchestrating AI coding agent sessions (Claude Code, Codex) with live previews and per-session state.
 - [burn](https://github.com/burn-rs/burn) - Comprehensive Deep Learning framework in Rust.
 - [cargo-selector](https://github.com/lusingander/cargo-selector) - Cargo subcommand to select and execute binary/example targets.
 - [claudectl](https://github.com/mercurialsolo/claudectl) - Mission control for multiple Claude Code sessions with live dashboard, cost tracking, and budget enforcement.


### PR DESCRIPTION
Adds [bosun](https://github.com/yetidevworks/bosun), a tmux-native TUI for orchestrating AI coding agent sessions (Claude Code, Codex) with live previews and per-session state. Built with Ratatui.