### PR TITLE
Add yscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [wireman](https://github.com/preiter93/wireman) - A gRPC client for the terminal.
 - [wiretui](https://github.com/robin-thoene/wiretui) - A minimal keyboard-driven TUI to manage WireGuard VPN connections.
 - [YADB](https://github.com/izya4ka/yadb) - A web directory brute-forcing tool.
+- [yscan](https://github.com/yetidevworks/yscan) - A TUI-first network scanner with ARP, mDNS, and SSDP discovery.
 
 ### 🚀 Productivity and Utilities
 


### PR DESCRIPTION
Adds [yscan](https://github.com/yetidevworks/yscan), a TUI-first network scanner with ARP, mDNS, and SSDP discovery. Built with Ratatui.