### PR TITLE
Add ytunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [wireman](https://github.com/preiter93/wireman) - A gRPC client for the terminal.
 - [wiretui](https://github.com/robin-thoene/wiretui) - A minimal keyboard-driven TUI to manage WireGuard VPN connections.
 - [YADB](https://github.com/izya4ka/yadb) - A web directory brute-forcing tool.
+- [ytunnel](https://github.com/yetidevworks/ytunnel) - A TUI-first CLI for managing Cloudflare Tunnels with custom domains.
 
 ### 🚀 Productivity and Utilities
 


### PR DESCRIPTION
Adds [ytunnel](https://github.com/yetidevworks/ytunnel), a TUI-first CLI for managing Cloudflare Tunnels with custom domains. Built with Ratatui.