### PR TITLE
Add hnr - terminal UI for Hacker News

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 ### 🤡 Social Media
 
 - [Chat-gRPC](https://github.com/Atheer2104/chat-grpc) - A Real-time Chat Microservice built in Rust using gRPC, including a TUI client.
+- [hnr](https://github.com/prasanthj/hnr) - A terminal UI for Hacker News — browse feeds, read threaded comments, vote, reply, search, and bookmark.
 - [iamb](https://github.com/ulyssa/iamb) - A matrix chat client with vim keybindings.
 - [lobtui](https://github.com/pythops/lobtui) - TUI for lobste.rs website.
 - [nostui](https://github.com/akiomik/nostui) - A TUI client for Nostr.


### PR DESCRIPTION
## Description

Adds [h.n.r](https://github.com/prasanthj/hnr) (say it as "honor"), a terminal UI for Hacker News built with ratatui 0.29.

**Features:**
- Six feeds: Top, New, Best, Ask HN, Show HN, Jobs
- Threaded comments with inline expand/collapse
- Comment prefetch — comments fetched automatically after a short dwell; pane switches without pressing Enter
- Reader mode — fetches and renders articles as structured text (headings, code blocks, quotes, lists) with section navigation
- Animated shimmer progress indicator for all async operations (feed refresh, article fetch, comment prefetch, search)
- Algolia-powered search
- Voting, replies, bookmarks, seen tracking
- User profiles, clipboard copy, browser open
- Login/session persistence
- Available via `cargo install hnr` and Homebrew

![h.n.r showcase](https://github.com/prasanthj/hnr/blob/main/showcase.gif?raw=true)