### PR TITLE
Add agx — step-through debugger for AI agent traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 
 ### ⌨️ Development Tools
 
-- [agx](https://github.com/brevity1swos/agx) - A step-through debugger for AI agent execution traces (Claude Code, Codex, Gemini, LangChain, Vercel AI SDK, OTel GenAI) with vim bindings, heatmap mode, and per-model cost estimates.
+- [agx](https://github.com/brevity1swos/agx) - A step-through debugger for AI agent execution traces.
 - [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client for your terminal.
 - [BugStalker](https://github.com/godzie44/BugStalker) - Modern rust debugger for Linux x86-64.
 - [blippy](https://github.com/AksharP5/blippy) - A keyboard-first TUI for GitHub issues and pull requests.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 
 ### ⌨️ Development Tools
 
+- [agx](https://github.com/brevity1swos/agx) - A step-through debugger for AI agent execution traces (Claude Code, Codex, Gemini, LangChain, Vercel AI SDK, OTel GenAI) with vim bindings, heatmap mode, and per-model cost estimates.
 - [ATAC](https://github.com/Julien-cpsn/ATAC) - A feature-full TUI API client for your terminal.
 - [BugStalker](https://github.com/godzie44/BugStalker) - Modern rust debugger for Linux x86-64.
 - [blippy](https://github.com/AksharP5/blippy) - A keyboard-first TUI for GitHub issues and pull requests.


### PR DESCRIPTION
## What is agx?

[agx](https://github.com/brevity1swos/agx) is a terminal TUI that turns AI agent session files into a navigable, color-coded timeline of user turns, assistant turns, tool calls, and tool results — with the original call input and response visible on a single screen. No SDK changes, no hosted dashboard — agx reads the JSONL/JSON files your agent CLI already writes.

Built with ratatui + crossterm.

## Format support

Auto-detects and parses 8 agent trace formats out of the box:
- Claude Code, Codex CLI, Gemini CLI (native JSONL/JSON)
- Generic OpenAI-compatible conversations
- LangChain / LangSmith run-tree exports
- Vercel AI SDK `generateText` / `streamText` results
- OpenTelemetry GenAI (JSON + binary protobuf)

## Key features

- Three-pane TUI with vim bindings, mouse support, count prefixes
- Bidirectional tool_use ↔ tool_result pairing across all formats
- Heatmap mode, time-travel scrubbing bar, content search with highlighting
- Per-model token usage and USD cost estimates
- Corpus mode (`agx corpus <dir>`) for cross-session aggregate stats
- Live attach (`--live`) for watching sessions in progress
- Export to Markdown / HTML / JSON / OpenAI trajectory JSONL
- MCP server (`agx-mcp`) for agent self-introspection

## Install

```bash
cargo install agx-tui
```

## Links

- Repository: https://github.com/brevity1swos/agx
- crates.io: https://crates.io/crates/agx-tui
- Library crate: https://crates.io/crates/agx-core

## Category

Added under **Development Tools** (alphabetically before BugStalker).