### PR TITLE
add crepuscularity to frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 ### 🏗️ Frameworks
 
 - [bevy_ratatui_camera](https://github.com/cxreiff/bevy_ratatui_camera) - A bevy plugin for rendering your bevy app to the terminal using ratatui.
+- [crepuscularity](https://github.com/tschk/crepuscularity) - One UI codebase for desktop, web, mobile, terminal, browser extensions, and embedded devices. Write React JSX or our lightweight DSL, get GPUI, Ratatui, SwiftUI, LVGL, and more. Batteries included.
 - [egui-ratatui](https://github.com/gold-silver-copper/egui_ratatui) - A ratatui backend that is also an egui widget. Deploy on web with WebAssembly or ship natively with bevy, macroquad, or eframe.
 - [mousefood](https://github.com/j-g00da/mousefood) - An embedded-graphics backend for Ratatui.
 - [dumo](https://github.com/iddey/dumo) - An embedded-graphics backend that is built on [mplusfonts](https://github.com/iddey/mplusfonts) and has kanji support.


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

hey there, here's my project called crepuscularity.

* Link to your project (GitHub/crates.io): https://github.com/tschk/crepuscularity 

* Description (optional):  Crepuscularity is a cross-platform UI framework and runtime ecosystem for building terminal apps, desktop apps, websites, browser extensions, mobile apps, and embedded interfaces from a single React JSX or lightweight DSL codebase. It supports Ratatui, GPUI, SwiftUI, HTML, browser extension targets, and embedded framebuffers/LVGL, with reusable components, hot reloading, runtime rendering, and compile-time generation built in.

* Screenshot or gif (strongly recommended): 
<img width="3024" height="1901" alt="image" src="https://github.com/user-attachments/assets/e4a536aa-a546-48e7-852e-2d7140353bb7" />

example is [plyght's](https://github.com/plyght/) [dot](https://github.com/tschk/dot) rewritten to use crepus' syntax.

<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->

thank you ratatui team!