### PR TITLE
Add pixtuoid to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [openapi-tui](https://github.com/zaghaghi/openapi-tui) - Terminal UI to list, browse and run APIs defined with openapi spec.
 - [opencode stats](https://github.com/Cateds/opencode-stats) - A terminal dashboard for OpenCode usage statistics and cost breakdowns.
 - [opencrabs](https://github.com/adolfousier/opencrabs) - Open-claw inspired orchestration layer for software development.
-- [pixtuoid](https://github.com/IvanWng97/pixtuoid) - Live pixel-art office for AI coding agents — each Claude Code session walks in, takes a desk, and animates per tool call.
+- [pixtuoid](https://github.com/IvanWng97/pixtuoid) - Live pixel-art office for AI coding agents.
 - [rainfrog](https://github.com/achristmascarl/rainfrog) - A database management TUI for Postgres.
 - [raygun](https://github.com/yetidevworks/raygun) - A terminal-based receiver for Spatie's Ray debugger, compatible with the Ray HTTP protocol used by PHP, Laravel, and Grav.
 - [raymon](https://github.com/bnomei/raymon) - Ray logging TUI and MCP Server.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [openapi-tui](https://github.com/zaghaghi/openapi-tui) - Terminal UI to list, browse and run APIs defined with openapi spec.
 - [opencode stats](https://github.com/Cateds/opencode-stats) - A terminal dashboard for OpenCode usage statistics and cost breakdowns.
 - [opencrabs](https://github.com/adolfousier/opencrabs) - Open-claw inspired orchestration layer for software development.
+- [pixtuoid](https://github.com/IvanWng97/pixtuoid) - Live pixel-art office for AI coding agents — each Claude Code session walks in, takes a desk, and animates per tool call.
 - [rainfrog](https://github.com/achristmascarl/rainfrog) - A database management TUI for Postgres.
 - [raygun](https://github.com/yetidevworks/raygun) - A terminal-based receiver for Spatie's Ray debugger, compatible with the Ray HTTP protocol used by PHP, Laravel, and Grav.
 - [raymon](https://github.com/bnomei/raymon) - Ray logging TUI and MCP Server.


### PR DESCRIPTION
Adds [pixtuoid](https://github.com/IvanWng97/pixtuoid) to **Apps → ⌨️ Development Tools** (alphabetical insert between \`opencrabs\` and \`rainfrog\`).

### What it is

A terminal pixel-art visualizer for AI coding agents — each running Claude Code session shows up as an animated half-block sprite walking around an ASCII coworking office. Built on ratatui (with a custom half-block compositor and \`Theme\` overlay) + crossterm + tokio.

Direct peers already in this section: \`bosun\`, \`claudectl\`, \`crmux\` (other Claude Code session viewers).

### Why ratatui

- Theme system threads a \`&'static Theme\` through the entire paint pipeline (6 built-in themes; live preview picker)
- Half-block (▀) compositor inside a ratatui Buffer for ~2× vertical resolution
- ratatui widgets layered on top for tooltips, footer, version popup, and the wall display ticker

### Eligibility

- ⭐ 83 stars, 4 forks, MIT, ~10k LOC Rust
- Published to crates.io as \`pixtuoid\`
- v0.4.1 shipped today; active CI (rustfmt, clippy -D warnings, tests, codecov)
![image](https://github.com/user-attachments/assets/65bc4fc3-74b6-4447-b966-f49b497edfd6)