### PR TITLE
Add quokka: TUI to inspect and clean an iPhone over USB

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [pumas](https://github.com/graelo/pumas) - Power Usage Monitor for Apple Silicon.
 - [purple](https://github.com/erickochen/purple) - TUI SSH config manager & launcher with fuzzy search, tags, cloud provider sync, tunnels and command snippets for server management.
 - [qmassa!](https://github.com/ulissesf/qmassa) - Displays GPU devices usage stats on Linux.
+- [quokka](https://github.com/dutradotdev/quokka) - A TUI to inspect and tidy a USB-connected iPhone from macOS: storage, apps, media, syslog viewer.
 - [slurmer](https://github.com/wjwei-handsome/Slurmer) - A TUI for monitoring and managing SLURM jobs.
 - [systemctl-tui](https://github.com/rgwood/systemctl-tui) - A fast, simple TUI for interacting with systemd services and their logs.
 - [systemd-manager-tui](https://github.com/matheus-git/systemd-manager-tui) - A program for managing systemd services through a TUI.


### PR DESCRIPTION
* Link to your project (GitHub/crates.io): https://github.com/dutradotdev/quokka
* Description: A TUI to inspect and tidy a USB-connected iPhone from macOS: storage, apps, media, and a syslog viewer. Built with ratatui. No jailbreak.
* Screenshot or gif: not included in this PR.

Added under System Administration, alphabetically between qmassa! and slurmer.
