### PR TITLE
Add oak-keyring

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [mprocs](https://github.com/pvolok/mprocs) - Run multiple commands in parallel and shows output of each command separately.
 - [neura-hustle-tracker](https://github.com/adolfousier/neura-hustle-tracker) - A privacy-first TUI to track what apps you use and how long you spend on them.
 - [numr](https://github.com/nasedkinpv/numr) - A natural language calculator with unit/currency conversions and vim-style keybindings.
+- [oak-keyring](https://github.com/OpenKeyring/oak-keyring) - A local-first password manager that keeps vault management interactive, keyboard-driven, and in the terminal.
 - [oracle](https://github.com/yashksaini-coder/oracle) - A TUI Rust codebase inspector to browse functions, structs, enums, traits, and more.
 - [ostt](https://github.com/kristoferlund/ostt) - Open Speech-to-Text recording tool with real-time volume metering and transcription.
 - [otree](https://github.com/fioncat/otree) - A command line tool to view objects (JSON/YAML/TOML) in TUI tree widget.


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io):
[`oak-keyring`](https://github.com/OpenKeyring/oak-keyring)

* Description: `oak-keyring` is a local-first password manager with a
full-screen, keyboard-driven terminal UI built with
[Ratatui](https://github.com/ratatui-org/ratatui). It keeps daily vault
management workflows such as browsing, searching, editing, tagging, recovery,
and copying credentials interactive and local.

* Screenshot or gif

![oak-keyring demo](https://github.com/OpenKeyring/oak-keyring/raw/master/examples/demo.gif)

---------

Signed-off-by: alpha <alphaqiu@gmail.com>