### PR TITLE
Add Yardlet to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [tongo](https://github.com/drewzemke/tongo) - A TUI for MongoDB.
 - [tracexec](https://github.com/kxxt/tracexec) - Tracer for execve{,at} and pre-exec behavior, launcher for debuggers.
 - [trex](https://github.com/blackopsrepl/trex) - A fast tmux session manager with fuzzy finding, per session stats and AI Agent tracking.
+- [Yardlet](https://github.com/zzunkie/yardlet) - A local AI workbench that turns intent into a verified task queue and drives your installed Claude Code or Codex CLIs as interchangeable workers.
 - [Yozefu](https://github.com/MAIF/yozefu/) - A TUI for exploring data of a Kafka cluster.
 - [Yazi](https://github.com/sxyazi/yazi) - Blazing fast terminal file manager written in Rust, based on async I/O.
 - [VLE](https://github.com/tuffy/vle) - A lightweight text editor.


### PR DESCRIPTION
Adds [Yardlet](https://github.com/zzunkie/yardlet) to **Apps → Development Tools**.

Yardlet is a local AI workbench built with Ratatui. You describe work in a few sentences; it plans an intent contract plus a verified task queue and runs each task through your installed Claude Code or Codex CLI (or any agent CLI via a generic adapter) as interchangeable workers, with a deterministic evaluator checking each result.

- Built with Ratatui (TUI) and clap.
- MIT licensed, published on crates.io: https://crates.io/crates/yardlet
- Single suggestion, placed alphabetically in the Development Tools section.
