### PR TITLE
Add quick-note

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [passepartui](https://github.com/kardwen/passepartui) - A TUI for pass.
 - [pgmon](https://github.com/nbari/pgmon) - A TUI for monitoring PostgresSQL databases.
 - [pgtui](https://codeberg.org/kdwarn/pgtui) - A PostgresSQL TUI client that utilizes your terminal text editor for inserts & updates.
+- [quick-note](https://github.com/daniel-valencia-ts/quick-note) - A simple note-taking tool.
 - [regect](https://github.com/kloki/regect) - A regex101 like tool for the cli.
 - [rgx](https://github.com/brevity1swos/rgx) - A terminal regex debugger with real-time matching, 3 engines, capture group highlighting, replace mode, and plain-English explanations.
 - [revw](https://github.com/rlelf/revw) - A vim-like TUI for managing notes and resources.


### PR DESCRIPTION
* Link to your project (GitHub/crates.io):
GitHub: https://github.com/daniel-valencia-ts/quick-note
crates.io: https://crates.io/crates/quick-note

* Description: quick-note is a tool that lets you easily create and manage small notes from your terminal with a simple interface.

* Screenshot or gif (strongly recommended): ![Simple showcase](https://i.postimg.cc/90fL9cBL/quick-note-simple-showcase.gif)