### PR TITLE
Add llmtrim to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [joshuto](https://github.com/kamiyaa/joshuto) - Ranger-like terminal file manager written in Rust.
 - [lazyjj](https://github.com/Cretezy/lazyjj) - TUI for the Jujutsu/jj VCS.
 - [lingora-tui](https://github.com/nigeleke/lingora) - Browse, compare and validate Fluent i18n files.
+- [llmtrim](https://github.com/fkiene/llmtrim) - Local proxy that compresses LLM API requests to cut token cost, with a tabbed status dashboard for per-source cost and context use.
 - [Maelstrom](https://github.com/maelstrom-software/maelstrom) - A fast test runner that runs every test in its own container locally or distributed.
 - [material](https://github.com/azorng/material) - A material design color palette for the terminal.
 - [nereid](https://github.com/bnomei/nereid) - Create and explore Mermaid diagrams in collaboration with AI agents (TUI + MCP Server).


### PR DESCRIPTION
Adds [llmtrim](https://github.com/fkiene/llmtrim) under **Apps -> Development Tools**.

llmtrim is a local proxy that compresses LLM API requests to cut token cost. Its `status` dashboard is a tabbed ratatui TUI (built with ratatui 0.29 + crossterm) showing per-source cost and context use down to the MCP server, and it opens by default when `status` runs on a TTY.

Entry placed alphabetically (after lingora-tui, before Maelstrom). Open source, MPL-2.0.