### PR TITLE
Add lazyslurm

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [kmon](https://github.com/orhun/kmon) - Linux Kernel Manager and Activity Monitor.
 - [kubectl-watch](https://github.com/imuxin/kubectl-watch) - A kubectl plugin to provide a pretty delta change view of being watched Kubernetes resources.
 - [kubetui](https://github.com/sarub0b0/kubetui) - TUI for real-time monitoring of Kubernetes resources.
+- [lazyslurm](https://github.com/hill/lazyslurm) - A lazygit-style terminal UI for Slurm. Monitor jobs, tail logs, and inspect nodes and partitions.
 - [logss](https://github.com/todoesverso/logss) - A simple cli for logs splitting.
 - [macmon](https://github.com/vladkens/macmon) - Sudoless performance monitoring for Apple Silicon processors.
 - [mirro-rs](https://github.com/rtkay123/mirro-rs) - An Arch Linux mirrorlist manager with a TUI.


### PR DESCRIPTION
* Link to your project (GitHub/crates.io): https://github.com/hill/lazyslurm

* Description: A lazygit-style terminal UI for Slurm. Monitor jobs, tail logs, and inspect nodes and partitions. Built with ratatui, MIT licensed, published on crates.io.

* Screenshot or gif:

![lazyslurm demo](https://github.com/hill/lazyslurm/raw/master/media/demo.gif)

Added under System Administration.
