### PR TITLE
Add dnsglobe to Networking and Internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [conclusive](https://github.com/mrusme/conclusive) - A command line client for Plausible Analytics.
 - [CuTE](https://github.com/PThorpe92/CuTE) - A libcurl powered HTTP Client with API-key/request mgmt and vim keybindings.
 - [discovery-rs](https://github.com/JustPretender/discovery-rs) - An utility to discover mDNS services on your network.
+- [dnsglobe](https://github.com/514-labs/dnsglobe) - Global DNS propagation checker querying 34 resolvers worldwide, with a world map.
 - [gping](https://github.com/orf/gping/) - Ping tool with a graph.
 - [impala](https://github.com/pythops/impala) - TUI for managing wifi on Linux.
 - [JocalSend](https://git.kittencollective.com/nebkor/joecalsend) - Peer to peer local file and data transfer, compatible with [LocalSend](https://github.com/localsend/localsend)


### PR DESCRIPTION
Adds [dnsglobe](https://github.com/514-labs/dnsglobe) — a global DNS propagation checker TUI. It queries 34 public DNS resolvers around the world in parallel, groups their answers (round-robin pools count as one answer), shows per-resolver status on a braille world map, and has a watch mode that re-polls until the record has propagated everywhere. Built with ratatui + crossterm + tokio + hickory-resolver.

Entry is alphabetized within the section.