### PR TITLE
Add iris to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [gobang](https://github.com/TaKO8Ki/gobang) - Cross-platform TUI database management tool.
 - [ilmari](https://github.com/bnomei/ilmari) - Minimal tmux popup radar to track your agents.
 - [image-auditor](https://github.com/0franco/image-auditor) - Find & fix Lighthouse image issues (CLS, lazy loading, WebP, srcset) across your codebase.
+- [iris](https://github.com/itzenata/iris-tui) - Live supervisor for every active Claude Code session - status, tokens, estimated cost, and one-pane approval of tool calls.
 - [joshuto](https://github.com/kamiyaa/joshuto) - Ranger-like terminal file manager written in Rust.
 - [lazyjj](https://github.com/Cretezy/lazyjj) - TUI for the Jujutsu/jj VCS.
 - [lingora-tui](https://github.com/nigeleke/lingora) - Browse, compare and validate Fluent i18n files.


### PR DESCRIPTION
Adds [iris](https://github.com/itzenata/iris-tui) — a live supervisor TUI for every active Claude Code session: per-session status, model, tokens, estimated cost (plus an aggregate counter), a live activity feed, and one-pane approval of pending tool calls via a PreToolUse hook.

Built with ratatui. Single static binary, MIT licensed, published on crates.io as [iris-tui](https://crates.io/crates/iris-tui).

Placed alphabetically in Apps → Development Tools.