### PR TITLE
Add alphai-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 ### 🚀 Productivity and Utilities
 
 - [absorb](https://github.com/kloki/absorb) - Quickly read a file without moving your eyes.
+- [alphai-tui](https://github.com/makeev/alphai-tui) - A stock dashboard with quotes, candlestick charts, AI-scored news and SEC Form 4 insider activity.
 - [atuin](https://github.com/atuinsh/atuin) - Magical shell history.
 - [basilk](https://github.com/GabAlpha/basilk) - A TUI to manage your tasks with minimal kanban logic.
 - [bbcli](https://github.com/hako/bbcli) - A terminal-based BBC News reader featuring a compact, numbered list interface with vim-like navigation.


### PR DESCRIPTION
Adds alphai-tui to Productivity and Utilities: a stock dashboard built with ratatui 0.30. Live quotes and candlestick charts (half-block candles, braille SMA/RSI overlays) next to AI-scored financial news and an SEC Form 4 insider stream. MIT, on crates.io. Author here.