### PR TITLE
Add nightlight-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [logss](https://github.com/todoesverso/logss) - A simple cli for logs splitting.
 - [macmon](https://github.com/vladkens/macmon) - Sudoless performance monitoring for Apple Silicon processors.
 - [mirro-rs](https://github.com/rtkay123/mirro-rs) - An Arch Linux mirrorlist manager with a TUI.
+- [nightlight-tui](https://github.com/umutdinceryananer/nightlightd) - Dashboard for the nightlightd screen colour temperature daemon.
 - [oxker](https://github.com/mrjackwills/oxker) - Simple TUI to view & control Docker containers.
 - [parui](https://github.com/Vonr/parui) - Simple TUI frontend for paru or yay.
 - [pumas](https://github.com/graelo/pumas) - Power Usage Monitor for Apple Silicon.


### PR DESCRIPTION
* Link to your project (GitHub/crates.io): https://github.com/umutdinceryananer/nightlightd

* Description (optional): nightlight-tui is the dashboard client of nightlightd, a zero-config screen colour temperature daemon for X11. Its default "live" theme follows the actual colour the screen is being filtered to, so the interface warms with the screen through the evening. It's my first Rust project and still young (v0.1.0), so if the description, section or anything else should be different, happy to change it however you prefer.

* Screenshot or gif (strongly recommended): https://github.com/umutdinceryananer/nightlightd/raw/main/docs/screenshots/01-now.png
