### PR TITLE
Add void focus app

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [tuxedo](https://github.com/webstonehq/tuxedo) - A fast, keyboard-driven terminal UI for todo.txt.
 - [vault-tasks](https://github.com/louis-thevenet/vault-tasks) - TUI Markdown Task Manager.
 - [visualvault](https://github.com/mikeleppane/visualvault) - A TUI for organizing media files.
+- [void](https://github.com/p6laris/Void) - A focus app with built-in task management, streak tracking, and customizable break schedules.
 - [wiper](https://github.com/ikebastuz/wiper) - Disk space analyzer and cleanup tool.
 - [work-tuimer](https://github.com/Kamyil/work-tuimer) - A TUI for easier time tracking each day, task-per-task with summaries.
 - [xan](https://github.com/medialab/xan) - A terminal tool for processing CSV files.


### PR DESCRIPTION
Added 'void' project to the list of TUIs in README.

<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): 
[Repo](https://github.com/p6laris/Void)
[Crates](https://crates.io/crates/void-focus/)

* Description (optional):  A focus app and task manager featuring subtasks, productivity statistics, and audio cues.

* Screenshot or gif (strongly recommended): 

<img width="1883" height="971" alt="Void" src="https://github.com/user-attachments/assets/9eab00cd-44f7-4daf-9e4e-83211f34b761" />

<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->