### PR TITLE
Add napwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [logss](https://github.com/todoesverso/logss) - A simple cli for logs splitting.
 - [macmon](https://github.com/vladkens/macmon) - Sudoless performance monitoring for Apple Silicon processors.
 - [mirro-rs](https://github.com/rtkay123/mirro-rs) - An Arch Linux mirrorlist manager with a TUI.
+- [napwatch](https://github.com/Tuguberk/napwatch) - Diagnoses and controls macOS power/battery behavior: dark wakes, Power Nap, live drain rate, and per-process power draw.
 - [nightlight-tui](https://github.com/umutdinceryananer/nightlightd) - Dashboard for the nightlightd screen colour temperature daemon.
 - [oxker](https://github.com/mrjackwills/oxker) - Simple TUI to view & control Docker containers.
 - [parui](https://github.com/Vonr/parui) - Simple TUI frontend for paru or yay.


### PR DESCRIPTION
Adding [napwatch](https://github.com/Tuguberk/napwatch) to the System Administration section.

napwatch is a terminal UI built with ratatui + crossterm for diagnosing and controlling macOS power/battery behavior: live instant-watt battery draw, a live sleep/wake event feed (to catch Power Nap-driven "dark wakes" that silently drain the battery overnight), a power-ranked process table with kill/renice, and toggles for Power Nap, Wake for network access, Low Power Mode, Standby, and TCP Keepalive.

- macOS only
- MIT licensed
- Distributed via Homebrew tap and `cargo install`