### PR TITLE
Add mxmon

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [logss](https://github.com/todoesverso/logss) - A simple cli for logs splitting.
 - [macmon](https://github.com/vladkens/macmon) - Sudoless performance monitoring for Apple Silicon processors.
 - [mirro-rs](https://github.com/rtkay123/mirro-rs) - An Arch Linux mirrorlist manager with a TUI.
+- [mxmon](https://github.com/yusufmo1/mxmon) - Sudoless Apple Silicon monitor with per-process watts, a live chassis heat map, and a JSON contract for scripts and agents.
 - [nightlight-tui](https://github.com/umutdinceryananer/nightlightd) - Dashboard for the nightlightd screen colour temperature daemon.
 - [oxker](https://github.com/mrjackwills/oxker) - Simple TUI to view & control Docker containers.
 - [parui](https://github.com/Vonr/parui) - Simple TUI frontend for paru or yay.


### PR DESCRIPTION
Adds [mxmon](https://github.com/yusufmo1/mxmon) to System Administration.

A sudoless Apple Silicon system monitor built with ratatui: per-process energy in watts, a live chassis thermal map, and a headless JSON contract (`snapshot`/`get`/`check`/`watch`) for scripts and agents. MIT, published on crates.io, and actively maintained.