### PR TITLE
Use GitHub link for ggsci-ratatui

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [bevy_ratatui](https://github.com/joshka/bevy_ratatui) - A Rust crate to use Ratatui in a Bevy App.
 - [color-to-tui](https://crates.io/crates/color-to-tui) - Parse colors and convert them to `ratatui::style::Colors`.
 - [coolor](https://github.com/Canop/coolor) - Tiny color conversion library for TUI application builders.
-- [ggsci-ratatui](https://crates.io/crates/ggsci-ratatui) - Scientific and sci-fi color palettes from ggsci as Ratatui colors and styles, in truecolor or ANSI-256 mode.
+- [ggsci-ratatui](https://github.com/nanxstats/ggsci-rs) - Scientific and sci-fi color palettes from ggsci as Ratatui colors and styles, in truecolor or ANSI-256 mode.
 - [opaline](https://crates.io/crates/opaline) - Token-based theme engine for Ratatui with gradients, 20 builtin themes, user theme discovery, and a reusable theme selector widget.
 - [ratatui-garnish](https://github.com/franklaranja/ratatui-garnish) - A powerful composition system for Ratatui widgets.
 - [ratatui-macros](https://github.com/kdheepak/ratatui-macros) - Macros for simplifying boilerplate for creating UI using Ratatui.


### PR DESCRIPTION
Follow-up to #374: replace the crates.io link for `ggsci-ratatui` with its GitHub repo link, as suggested by @orhun. The vhs recording is also updated to slow things down. Note the repo is a workspace containing multiple crates, hence the name difference (`ggsci-rs`).

* Link to your project (GitHub/crates.io): https://github.com/nanxstats/ggsci-rs

* Description (optional): Scientific and sci-fi color palettes from ggsci as Ratatui colors and styles, in truecolor or ANSI-256 mode.

* Screenshot or gif (strongly recommended):

  ![Interactive palette gallery cycling through the discrete, continuous, iTerm, and Gephi tabs](https://github.com/user-attachments/assets/0451593e-cf48-44e7-907e-8a798a78730c)