### PR TITLE
Add mirador

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [matchmaker](https://github.com/Squirreljetpack/matchmaker) - Fuzzy picker (FZF reboot).
 - [md-tui](https://github.com/henriklovhaug/md-tui) - Markdown renderer in the terminal.
 - [meteo-tui](https://github.com/16arpi/meteo-tui) - French weather app in the command line.
-- [mirador](https://github.com/jchultarsky/mirador) - A personal dashboard: world clocks, calendar and `.ics` agenda, weather, tasks, notes, a market watchlist and live CPU and network graphs, in a configurable grid.
+- [mirador](https://github.com/jchultarsky/mirador) - A personal dashboard with world clocks, calendar, weather, tasks, notes, a market watchlist and live CPU and network graphs.
 - [models](https://github.com/arimxyer/models) - A TUI for browsing AI models, benchmarks, and coding agents.
 - [mprocs](https://github.com/pvolok/mprocs) - Run multiple commands in parallel and shows output of each command separately.
 - [neura-hustle-tracker](https://github.com/adolfousier/neura-hustle-tracker) - A privacy-first TUI to track what apps you use and how long you spend on them.

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [matchmaker](https://github.com/Squirreljetpack/matchmaker) - Fuzzy picker (FZF reboot).
 - [md-tui](https://github.com/henriklovhaug/md-tui) - Markdown renderer in the terminal.
 - [meteo-tui](https://github.com/16arpi/meteo-tui) - French weather app in the command line.
+- [mirador](https://github.com/jchultarsky/mirador) - A personal dashboard: world clocks, calendar and `.ics` agenda, weather, tasks, notes, a market watchlist and live CPU and network graphs, in a configurable grid.
 - [models](https://github.com/arimxyer/models) - A TUI for browsing AI models, benchmarks, and coding agents.
 - [mprocs](https://github.com/pvolok/mprocs) - Run multiple commands in parallel and shows output of each command separately.
 - [neura-hustle-tracker](https://github.com/adolfousier/neura-hustle-tracker) - A privacy-first TUI to track what apps you use and how long you spend on them.


### PR DESCRIPTION
[mirador](https://github.com/jchultarsky/mirador) — a personal dashboard for the terminal, built with ratatui.

World clocks, a calendar and an `.ics` agenda, weather, a full task list with due dates and priorities, notes, a market watchlist and live CPU and network graphs, laid out in a configurable grid you can change from inside the app.

- **crates.io:** https://crates.io/crates/mirador · **MIT** · Rust 1.95+
- macOS, Linux and Windows, with prebuilt binaries and one-line installers
- CI runs tests on all three platforms plus clippy, rustdoc, MSRV, `cargo publish --dry-run` and `cargo-deny`

Added to *Productivity and Utilities*, alphabetically between `meteo-tui` and `models`.

There is a 30-second recording in the README if it helps to see it moving.