### PR TITLE
Add myx to Music and Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [mal-cli](https://github.com/L4z3x/mal-cli) - A TUI for myanimelist.
 - [managarr](https://github.com/Dark-Alex-17/managarr) - A TUI and CLI for managing all your Servarrs.
 - [manga-tui](https://github.com/josueBarretogit/manga-tui) - Terminal-based manga reader and downloader with image support.
+- [myx](https://github.com/HaseebKhalid1507/Myx) - Modern Spotify player for the terminal. With reactive themes.
 - [NoctaVox](https://github.com/Jaxx497/noctavox) - A lightweight, customizable TUI music player for local files.
 - [O₂](https://github.com/coignard/o2) - Rust port of the ORCΛ esoteric programming language and terminal livecoding environment.
 - [oosc-rs](https://github.com/karasikq/oosc-rs) - An additive wavetable synthesizer for terminal.


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): https://github.com/HaseebKhalid1507/Myx

* Description (optional): A Terminal native music player built in Rust. It uses a lot of the spotify_player code. I mainly built this because I wanted a CLI tool that looked beautiful and wouldn't take like 400MB to run and didn't recommend podcasts every 5 mins. 

* Screenshot or gif (strongly recommended): <video src="https://github.com/user-attachments/assets/208eaa73-c1be-4296-bd6d-b7efa1272b03"></video>

<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app



* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->