### PR TITLE
Add xnano to frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [widgetui](https://crates.io/crates/widgetui) - A bevy-like widget system for ratatui and crossterm.
 - [rat-salsa](https://github.com/thscharler/rat-salsa) - An event-queue for ratatui with tasks, timers, application events, focus handling, dialog windows.
 - [raclettui](https://github.com/ishrut/raclettui) - A wayland layer shell window implementing the ratatui backend with cpu and wgpu rendering.
+- [xnano](https://github.com/hsaeed3/xnano) - A declarative terminal framework for Python built on ratatui & ratzilla.
 
 ### 🧩 Widgets
 


### PR DESCRIPTION
* Link to your project (GitHub/crates.io): https://github.com/hsaeed3/xnano

* Description (optional): A declarative terminal framework for Python built on ratatui and ratzilla.

* Screenshot or gif (strongly recommended): https://github.com/hsaeed3/xnano/blob/main/docs/assets/examples/agent_chat-dark.gif?raw=true