### PR TITLE
Add malevich

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [ratatui-wireframe](https://crates.io/crates/ratatui-wireframe) -  A widget for rendering and rotating 3D wireframe models.
 - [edtui](https://github.com/preiter93/edtui) - A TUI based vim-inspired editor widget for ratatui.
 - [hyperrat](https://crates.io/crates/hyperrat) - An OSC 8 link widget for ratatui.
+- [malevich](https://crates.io/crates/malevich) - A plotting widget: line, scatter, bar, histogram, heatmap, box plot, violin, and more, with automatic axes and millions of points.
 - [ratatui-comfy-tabs](https://crates.io/crates/ratatui-comfy-tabs) - A feature-rich tab navigation for TUI. Highly customizable.
 - [ratatui-comfy-toaster](https://crates.io/crates/ratatui-comfy-toaster) - An advanced toast notification engine for Ratatui terminal UI applications.
 - [ratatui-explorer](https://github.com/tatounee/ratatui-explorer) - A simple library for creating file explorer for ratatui.


### PR DESCRIPTION
Adds [malevich](https://crates.io/crates/malevich) to the Widgets section — a terminal plotting library (line, scatter, bar, histogram, heatmap, box plot, violin, and more) whose `ratatui` feature renders any chart as a widget, depending only on `ratatui-core`.