### PR TITLE
Add readio

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [NoctaVox](https://github.com/Jaxx497/noctavox) - A lightweight, customizable TUI music player for local files.
 - [O₂](https://github.com/coignard/o2) - Rust port of the ORCΛ esoteric programming language and terminal livecoding environment.
 - [oosc-rs](https://github.com/karasikq/oosc-rs) - An additive wavetable synthesizer for terminal.
+- [readio](https://github.com/hrhrng/readio) - A terminal ebook reader for EPUB, PDF, Markdown, and plain text with optional local text-to-speech.
 - [roon-tui](https://github.com/TheAppgineer/roon-tui) - Roon Remote for the terminal.
 - [rs-pug](https://github.com/JustRoccat/rs-pug) - A Neovim-inspired asynchronous music player with a reactive audio visualizer.
 - [rusty-pipes](https://github.com/dividebysandwich/rusty-pipes) - Sample-based, MIDI-controlled virtual pipe organ instrument.


### PR DESCRIPTION
## Summary

- add [readio](https://github.com/hrhrng/readio) to Music and Media
- describe it as a terminal ebook reader for EPUB, PDF, Markdown, and plain text with optional local text-to-speech

Readio uses [Ratatui](https://github.com/ratatui/ratatui) directly for its TUI and is an interactive, open-source terminal application. Product page: https://read-io.com/tui

Validation: `git diff --check`