### PR TITLE
Add reeve

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [purple](https://github.com/erickochen/purple) - TUI SSH config manager & launcher with fuzzy search, tags, cloud provider sync, tunnels and command snippets for server management.
 - [qmassa!](https://github.com/ulissesf/qmassa) - Displays GPU devices usage stats on Linux.
 - [quokka](https://github.com/dutradotdev/quokka) - A TUI to inspect and tidy a USB-connected iPhone from macOS: storage, apps, media, syslog viewer.
+- [reeve](https://github.com/yetidevworks/reeve) - Manages a local web stack as per-user services: Caddy, Apache or nginx, per-vhost PHP-FPM versions, databases, local SSL, and wildcard DNS.
 - [slurmer](https://github.com/wjwei-handsome/Slurmer) - A TUI for monitoring and managing SLURM jobs.
 - [systemctl-tui](https://github.com/rgwood/systemctl-tui) - A fast, simple TUI for interacting with systemd services and their logs.
 - [systemd-manager-tui](https://github.com/matheus-git/systemd-manager-tui) - A program for managing systemd services through a TUI.


### PR DESCRIPTION
Adds [reeve](https://github.com/yetidevworks/reeve), a local web development stack manager for macOS and Linux: Caddy/Apache/nginx, per-vhost PHP-FPM versions running side by side, databases, trusted local SSL via mkcert, and wildcard `.test` DNS, all as per-user launchd/systemd services with no root daemon. Built with Ratatui.

Filed under System Administration rather than Development Tools since it manages long-running services. Note this is unrelated to the existing [Reeve](https://github.com/Dancode-188/reeve) entry under Development Tools, which is an AI agent cockpit. Same name, different project.