### PR TITLE
Add LazyMQTT to Networking and Internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [gping](https://github.com/orf/gping/) - Ping tool with a graph.
 - [impala](https://github.com/pythops/impala) - TUI for managing wifi on Linux.
 - [JocalSend](https://git.kittencollective.com/nebkor/joecalsend) - Peer to peer local file and data transfer, compatible with [LocalSend](https://github.com/localsend/localsend)
+- [LazyMQTT](https://github.com/ScottFelder/lazymqtt) - Terminal UI MQTT client with features like saved connections, live topic tree, and message inspector.
 - [mqttui](https://github.com/EdJoPaTo/mqttui) - MQTT client for subscribing or publishing to topics.
 - [mullvad-tui](https://github.com/d10n/mullvad-tui) - A TUI for Mullvad VPN.
 - [mxr](https://github.com/planetaryescape/mxr) - Local-first email client with Vim-style navigation, multi-account sync, and full-text search.


### PR DESCRIPTION
<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): https://github.com/ScottFelder/lazymqtt

* Description (optional):  A fast, terminal-UI MQTT client written in Rust — inspired by MQTT Explorer, but keyboard-driven and living in your terminal.

* Screenshot or gif (strongly recommended): https://github.com/ScottFelder/lazymqtt/blob/master/assets/demo.gif


<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->