### PR TITLE
Add termlens

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [ratatui-interact](https://github.com/Brainwires/ratatui-interact) - Interactive TUI components for Ratatui with focus management and mouse support.
 - [tachyonfx](https://github.com/junkdog/tachyonfx) - A shader-like effects library for ratatui.
 - [terminput](https://crates.io/crates/terminput) - An abstraction over various backends that provide input events.
+- [termlens](https://github.com/vyncint/termlens) - A headless PTY test harness: spawn a TUI in a real PTY and assert or snapshot on the emulated screen.
 - [termprofile](https://github.com/aschey/termprofile) - Detect and handle terminal color/styling support. Supports converting Ratatui color and style objects.
 - [tui-input](https://crates.io/crates/tui-input) - A headless input library for TUI apps.
 - [tui-pantry](https://crates.io/crates/tui-pantry) - Component-driven development tool for ratatui widgets, similar to Storybook.


### PR DESCRIPTION
Adds [termlens](https://github.com/vyncint/termlens) to Libraries → Utilities: a headless PTY test harness — spawn a CLI/TUI app in a real PTY, drive it with typed key input, and assert or snapshot on the emulated screen grid (insta integration included). Released as v0.1.0 on crates.io today; CI-tested on Linux and macOS with a 100-iteration cross-OS stress gate.

Entry placed alphabetically; format follows the surrounding items.