### PR TITLE
Add p2pmux to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [Oatmeal](https://github.com/dustinblackman/oatmeal) - Terminal UI to chat with large language models (LLM) using different model backends, and integrations with your favourite editors!
 - [openapi-tui](https://github.com/zaghaghi/openapi-tui) - Terminal UI to list, browse and run APIs defined with openapi spec.
 - [opencode stats](https://github.com/Cateds/opencode-stats) - A terminal dashboard for OpenCode usage statistics and cost breakdowns.
+- [p2pmux](https://github.com/pelazas/p2pmux) - A peer-to-peer terminal multiplexer where every pane is a PTY on its owner's own machine, with an inbox of the coding agents running across all of them.
 - [patent](https://github.com/r14dd/patent) - A prior-art search for devtool ideas.
   LLM verdict.
 - [opencrabs](https://github.com/adolfousier/opencrabs) - Open-claw inspired orchestration layer for software development.


### PR DESCRIPTION
[p2pmux](https://github.com/pelazas/p2pmux) — a terminal multiplexer built with ratatui 0.30, MIT, macOS and Linux on both architectures.

Zellij-like tabs, panes and nested splits, except the grid spans machines: every pane is a PTY on the machine of whoever opened it, with that machine's shell, PATH and env. You join with a ten-character code and land in a shared grid where some panes are on your laptop and some are on someone else's box; panes stream peer-to-peer over iroh, and the tab bar prints `direct 55ms` or `relayed 120ms` so you can see which path you got.

Placed in Development Tools rather than Networking because of what it is mostly used for. This section already has several TUIs that supervise coding agents — bosun, claudectl, crmux, iris, thurbox, trex — and they all watch agents running in tmux on one box. p2pmux's inbox does the same job across every machine in the session: it lists every Claude Code, Codex, Cursor, Pi and OpenCode agent on all of them, sorted by which one is blocking a human, with state coming from the agents' own hooks rather than from guessing at output timing. A laptop and two droplets is a normal session.

Alphabetical position between `opencode stats` and `patent`.

Ratatui specifics, in case they are of interest: `default-features = false` with just the crossterm feature, a nested-split layout tree rendered per frame, and the whole UI is snapshot-tested by replaying the emitted bytes through a vt100 parser in a real PTY, which catches partial-repaint bugs that substring assertions miss.