### PR TITLE
Add sgram-tui to Music and Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [rusty-pipes](https://github.com/dividebysandwich/rusty-pipes) - Sample-based, MIDI-controlled virtual pipe organ instrument.
 - [scope-tui](https://github.com/alemidev/scope-tui) - A simple oscilloscope/vectorscope/spectroscope for your terminal.
 - [serenIT](https://github.com/ElevenJune/serenIT) - An ambient sound player directly from your terminal.
+- [sgram-tui](https://github.com/arian-shamaei/sgram-tui) - A calibrated spectrogram analyzer for live mic or audio files, with labeled PNG figure export and a headless render mode.
 - [smyx](https://github.com/ayanchavand/Smyx) - A sleek, beautiful music player for Navidrome / OpenSubsonic with dynamic themes.
 - [sparkplayer](https://github.com/dividebysandwich/sparkplayer/tree/main) - A fun terminal based media player with album art and video support.
 - [spotatui](https://github.com/LargeModGames/spotatui) - Spotify client with native streaming, synced lyrics, and audio visualization. A direct fork of spotify-tui with continued development and new features.


### PR DESCRIPTION
Adds **[sgram-tui](https://github.com/arian-shamaei/sgram-tui)** — a calibrated spectrogram analyzer for the terminal (live mic or wav/mp3/flac/ogg/m4a), with mouse-hover time/frequency/dB readout, labeled PNG figure export, and a headless render mode.

![sgram-tui live-rendering the WAV that spells its own name](https://raw.githubusercontent.com/arian-shamaei/sgram-tui/main/docs/assets/hero.gif)

The GIF is the tool rendering a WAV whose spectrogram spells the tool's name (the generator script ships in the repo). Placed alphabetically in Music and Media, next to its inspiration scope-tui.