### PR TITLE
Add ghx

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [git-time-machine](https://github.com/dinakars777/git-time-machine) - Visual Git reflog TUI for undoing Git mistakes.
 - [gitui](https://github.com/extrawurst/gitui) - Terminal UI for Git.
 - [Gitside](https://github.com/dev-bhaskar8/gitside) - A responsive, mouse-friendly Git source-control TUI for full terminals and narrow tmux panes.
+- [ghx](https://github.com/tknawara/ghx) - A modal TUI for browsing remote forges (GitHub in-tree, others via stdio providers) with miller columns and syntax-highlighted previews.
 - [glim](https://github.com/junkdog/glim) - Monitor GitLab CI/CD pipelines and projects with style.
 - [gmsg](https://github.com/olorikendrick/gmsg) - Generate, edit, and commit AI-powered Git commit messages from a single TUI.
 - [gobang](https://github.com/TaKO8Ki/gobang) - Cross-platform TUI database management tool.


### PR DESCRIPTION
[ghx](https://github.com/tknawara/ghx) is a modal TUI (ratatui + crossterm) for browsing remote source-control systems: yazi-style miller-column browser, syntax-highlighted previews (syntect), Zed-style global search, and a pluggable stdio provider seam — GitHub ships in-tree.