### PR TITLE
rootle: point at the rootledev org + rootle.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [rainfrog](https://github.com/achristmascarl/rainfrog) - A database management TUI for Postgres.
 - [raygun](https://github.com/yetidevworks/raygun) - A terminal-based receiver for Spatie's Ray debugger, compatible with the Ray HTTP protocol used by PHP, Laravel, and Grav.
 - [raymon](https://github.com/bnomei/raymon) - Ray logging TUI and MCP Server.
-- [rootle](https://github.com/tknawara/rootle) - A modal TUI for browsing remote forges (GitHub in-tree, others via stdio providers) with miller columns and syntax-highlighted previews.
+- [rootle](https://github.com/rootledev/rootle) - A modal TUI for browsing remote forges (GitHub in-tree, others via stdio providers) with miller columns and syntax-highlighted previews. ([website](https://rootle.dev/))
 - [sabiql](https://github.com/riii111/sabiql) - A fast, driver-less TUI for browsing, querying, and editing PostgreSQL databases with vim-like keybindings.
 - [ratatui-form](https://github.com/DavidLiedle/ratatui-form) - A form library for ratatui.
 - [ratifact](https://github.com/adolfousier/ratifact) - Track and manage build artifacts from multiple programming languages.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [rainfrog](https://github.com/achristmascarl/rainfrog) - A database management TUI for Postgres.
 - [raygun](https://github.com/yetidevworks/raygun) - A terminal-based receiver for Spatie's Ray debugger, compatible with the Ray HTTP protocol used by PHP, Laravel, and Grav.
 - [raymon](https://github.com/bnomei/raymon) - Ray logging TUI and MCP Server.
-- [rootle](https://github.com/rootledev/rootle) - A modal TUI for browsing remote forges (GitHub in-tree, others via stdio providers) with miller columns and syntax-highlighted previews. ([website](https://rootle.dev/))
+- [rootle](https://github.com/rootledev/rootle) - A modal TUI for browsing remote forges (GitHub in-tree, others via stdio providers) with miller columns and syntax-highlighted previews.
 - [sabiql](https://github.com/riii111/sabiql) - A fast, driver-less TUI for browsing, querying, and editing PostgreSQL databases with vim-like keybindings.
 - [ratatui-form](https://github.com/DavidLiedle/ratatui-form) - A form library for ratatui.
 - [ratifact](https://github.com/adolfousier/ratifact) - Track and manage build artifacts from multiple programming languages.


### PR DESCRIPTION
Follow-up to #411 (which itself followed #410 — apologies for the churn, this should be the last move). The project moved from my personal account to the [rootledev](https://github.com/rootledev) org to make room for sibling repos (providers, homebrew tap). GitHub redirects the old URL, but the list should point at the canonical home.

Also adds the project website link: https://rootle.dev/ (docs, per-theme demo GIFs, install script).