### PR TITLE
Add ratiform to widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [ratatui-cheese](https://crates.io/crates/ratatui-cheese) - Bubbletea-inspired widgets for ratatui, including spinner, help, tree, paginator and list.
 - [ratatui-code-editor](https://github.com/vipmax/ratatui-code-editor) - A code editor widget for ratatui, syntax highlighting powered by tree-sitter.
 - [ratatui-markdown](https://github.com/celestia-island/ratatui-markdown) - A Rust library providing markdown rendering, Mermaid diagrams, syntax highlighting, collapsible JSON/TOML tree views, and a rich hybrid scroll system.
+- [ratiform](https://crates.io/crates/ratiform) - A stateful form widget with typed field identifiers, so your data model stays your own, not the library's.
 - [term-rustdoc](https://github.com/zjp-CN/term-rustdoc) - A TUI for Rust docs that aims to improve the UX on tree view and generic code.
 - [throbber-widgets-tui](https://crates.io/crates/throbber-widgets-tui) - A widget that displays throbber.
 - [tui-additions](https://crates.io/crates/tui-additions) - Additions to the rust tui crate.


### PR DESCRIPTION
* Link to your project (GitHub/crates.io): https://crates.io/crates/ratiform
* Description (optional): A stateful form widget for Ratatui with typed field identifiers, so your data model stays your own, not the library's.
* Screenshot or gif (strongly recommended): https://github.com/user-attachments/assets/1652a596-cbf9-4cd1-b58c-cd9f2815a0f7