### PR TITLE
Add hedos

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [gmsg](https://github.com/olorikendrick/gmsg) - Generate, edit, and commit AI-powered Git commit messages from a single TUI.
 - [gobang](https://github.com/TaKO8Ki/gobang) - Cross-platform TUI database management tool.
 - [gwm](https://github.com/kbrdn1/gwm-cli) - A Git worktree manager: CLI and TUI in one binary, native libgit2, per-repo declarative bootstrap, and AI agent session tracking.
+- [hedos](https://github.com/theiskaa/hedos) - A terminal shelf for the local AI models already on your machine, with a built-in OpenAI-compatible gateway.
 - [ilmari](https://github.com/bnomei/ilmari) - Minimal tmux popup radar to track your agents.
 - [image-auditor](https://github.com/0franco/image-auditor) - Find & fix Lighthouse image issues (CLS, lazy loading, WebP, srcset) across your codebase.
 - [iris](https://github.com/itzenata/iris-tui) - Live supervisor for every active Claude Code session - status, tokens, estimated cost, and one-pane approval of tool calls.


### PR DESCRIPTION
Adds hedos under Apps → Development Tools, in alphabetical order between `gwm` and `ilmari`:

`- [hedos](https://github.com/theiskaa/hedos) - A terminal shelf for the local AI models already on your machine, with a built-in OpenAI-compatible gateway.`

hedos is a Rust binary that discovers the local models already on a machine (the Ollama store, the Hugging Face cache, LM Studio's library, loose GGUF and safetensors files) without moving a byte, resolves each to the runtime that can serve it, and exposes them over a local OpenAI/Ollama-compatible gateway. `hedos shelf` is the ratatui interface: the shelf, install progress, and an in-terminal chat pane.

Single suggestion, one entry, description ends with a period, no trailing whitespace, and the GitHub link resolves.