### PR TITLE
Add LimitDeck

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [joshuto](https://github.com/kamiyaa/joshuto) - Ranger-like terminal file manager written in Rust.
 - [lazyjj](https://github.com/Cretezy/lazyjj) - TUI for the Jujutsu/jj VCS.
 - [Livediff](https://github.com/SoCkEt7/Livediff) - Real-time terminal file diff monitoring TUI.
+- [LimitDeck](https://github.com/rockythink/limitdeck) - A compact, privacy-safe terminal dashboard for AI coding subscription limits.
 - [lingora-tui](https://github.com/nigeleke/lingora) - Browse, compare and validate Fluent i18n files.
 - [llmtrim](https://github.com/fkiene/llmtrim) - Local proxy that compresses LLM API requests to cut token cost, with a tabbed status dashboard for per-source cost and context use.
 - [Maelstrom](https://github.com/maelstrom-software/maelstrom) - A fast test runner that runs every test in its own container locally or distributed.


### PR DESCRIPTION
* Link to your project (GitHub/crates.io): https://github.com/rockythink/limitdeck

* Description (optional): A compact, privacy-safe terminal dashboard for AI coding subscription limits.

* Screenshot or gif (strongly recommended): https://raw.githubusercontent.com/rockythink/limitdeck/main/assets/limitdeck.gif