### PR TITLE
Updated budget-tracker-tui name, link & description

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [bluetui](https://github.com/pythops/bluetui) - A TUI for managing Bluetooth devices.
 - [brew-explorer](https://github.com/cosmincatalin/brew-explorer) - A TUI for exploring and managing your Homebrew packages with ease.
 - [btlescan](https://github.com/ztroop/btlescan) - Bluetooth Low Energy (BTLE) scanner and GATT viewer.
-- [budget_tracker_tui](https://github.com/Feromond/budget_tracker_tui) - A fast, keyboard-driven TUI for tracking expenses, managing categories, and analyzing your budget with ease.
+- [budget-tracker-tui](https://github.com/Feromond/budget-tracker-tui) - A fast, keyboard-driven TUI for tracking expenses, tracking investments, and analyzing your budget with ease.
 - [chamber](https://github.com/mikeleppane/chamber) - A TUI for managing secrets.
 - [codemark](https://github.com/DanielCardonaRojas/codemark) - A semantic code bookmarking system for humans and agents.
 - [columbus](https://github.com/sivaprakashkrp/columbus) - A GUI-like TUI file explorer.


### PR DESCRIPTION
Corrected the spelling of 'budget_tracker_tui' to 'budget-tracker-tui' and updated the description to include tracking investments. Updated to use the new GitHub URL so it doesn't have to re-direct, and so that it is correctly represented.

<!-- Thanks for making Ratatui awesome! 🐭 -->

* Link to your project (GitHub/crates.io): <!-- paste here -->
https://github.com/Feromond/budget-tracker-tui

* Description (optional):  <!-- short summary -->
Was already submitted before, just updating description details etc.

* Screenshot or gif (strongly recommended): <!-- drag & drop or link -->
<img width="2000" height="1226" alt="budget-tracker-tour-gif" src="https://github.com/user-attachments/assets/a75dfd50-128e-4d45-8569-2641bc6cfd05" />

<!--

### Tips 💡

* See how to release apps: https://ratatui.rs/recipes/apps/release-your-app
* Share it in our Discord: https://discord.gg/DkvdWRPJ 
* Share it in our Forum: https://forum.ratatui.rs/
* Add this badge to your README for showing off:

```md
[![Built With Ratatui](https://ratatui.rs/built-with-ratatui/badge.svg)](https://ratatui.rs/)
```

-->